### PR TITLE
removing unreliable source per WP:RSPS

### DIFF
--- a/annotations.xml
+++ b/annotations.xml
@@ -7,7 +7,6 @@
 <Annotation about="*.klov.com/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.euskomedia.org/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.emporis.com/*"><Label name="_include_"></Label></Annotation>
-<Annotation about="*.globalsecurity.org/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.marxists.org/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.faqs.org/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.amnesty.org/*"><Label name="_include_"></Label></Annotation>


### PR DESCRIPTION
https://en.wikipedia.org/w/index.php?title=Wikipedia:GLOBALSECURITY&redirect=no