### PR TITLE
Remove an annotation for '*.iht.com/*'

### DIFF
--- a/annotations.xml
+++ b/annotations.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Annotations>
   <!-- Misc urls to investigate reliability -->
-<Annotation about="*.iht.com/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.hbw.com/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.stationreporter.net/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.klov.com/*"><Label name="_include_"></Label></Annotation>


### PR DESCRIPTION
International Herald Times is now defunct and redirects to nytimes.com (same owner). https://en.wikipedia.org/wiki/International_Herald_Tribune