### PR TITLE
Replace klov.com annotation with arcade-museum.com

### DIFF
--- a/annotations.xml
+++ b/annotations.xml
@@ -4,7 +4,7 @@
 <Annotation about="*.iht.com/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.hbw.com/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.stationreporter.net/*"><Label name="_include_"></Label></Annotation>
-<Annotation about="*.klov.com/*"><Label name="_include_"></Label></Annotation>
+<Annotation about="*.arcade-museum.com/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.euskomedia.org/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.emporis.com/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.globalsecurity.org/*"><Label name="_include_"></Label></Annotation>


### PR DESCRIPTION
replacing url with its current redirect destination - seems to be the same site at first glance