### PR TITLE
Remove emporis.com annotation

### DIFF
--- a/annotations.xml
+++ b/annotations.xml
@@ -6,7 +6,7 @@
 <Annotation about="*.stationreporter.net/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.klov.com/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.euskomedia.org/*"><Label name="_include_"></Label></Annotation>
-<Annotation about="*.emporis.com/*"><Label name="_include_"></Label></Annotation>
+<Annotation about="*.globalsecurity.org/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.marxists.org/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.faqs.org/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.amnesty.org/*"><Label name="_include_"></Label></Annotation>


### PR DESCRIPTION
Removed annotation for emporis.com from the list. Skydb.net seems to be successor site but not sure how useful it is. Pretty niche site about the height of tall buildings