### PR TITLE
Delete iht, stationreporter

### DIFF
--- a/annotations.xml
+++ b/annotations.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Annotations>
   <!-- Misc urls to investigate reliability -->
-<Annotation about="*.iht.com/*"><Label name="_include_"></Label></Annotation>
-<Annotation about="*.stationreporter.net/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.euskomedia.org/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.emporis.com/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.marxists.org/*"><Label name="_include_"></Label></Annotation>


### PR DESCRIPTION
Removed two annotations for '.iht.com' and '.stationreporter.net’. Neither domain still exists and projects seem defunct or hidden in archives somewhere