### PR TITLE
Remove annotation for britannica.com

### DIFF
--- a/annotations.xml
+++ b/annotations.xml
@@ -299,7 +299,6 @@
 <Annotation about="*.gutenberg.org/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.biographi.ca/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.ethnologue.com/*"><Label name="_include_"></Label></Annotation>
-<Annotation about="*.britannica.com/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.ibiblio.org/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.archives.gov/*"><Label name="_include_"></Label></Annotation>
 <Annotation about="*.british-history.ac.uk/*"><Label name="_include_"></Label></Annotation>


### PR DESCRIPTION
Removed annotation for *.britannica.com/* from the list. Rated ‘no consensus’ on WP:RSPS: https://en.wikipedia.org/w/index.php?title=Wikipedia:BRITANNICA&redirect=no